### PR TITLE
Fix maximum call stack error

### DIFF
--- a/paymentEncoder.js
+++ b/paymentEncoder.js
@@ -5,7 +5,7 @@ var percentFlag = 0x20
 var sffc = require('sffc-encoder')
 
 var padLeadingZeros = function (hex, byteSize) {
-  return (hex.length === byteSize * 2) && hex || padLeadingZeros('0' + hex, byteSize)
+  return hex.padStart(byteSize * 2, '0')
 }
 
 module.exports = {


### PR DESCRIPTION
When you use multiple inputs and addresses have more than 1 transaction